### PR TITLE
poor syntax

### DIFF
--- a/hello-css/dummy.html
+++ b/hello-css/dummy.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang='en'>
   <head>
-    <meta charset='UTF-8'/>
+    <meta charset='UTF-8'>
     <title>Dummy</title>
-    <link rel='stylesheet' href='styles.css'/>
+    <link rel='stylesheet' href='styles.css'>
     <style>
       body {
         color: #0000FF;


### PR DESCRIPTION
The back slash is used for closing a tag. Since, meta and link tag don't have a closing tag, the back slash is not needed.